### PR TITLE
Move contributing guidelines to repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+## Contributing
+
+Thank you everyone for contributing to this project.
+
+Pull requests for new features and major fixes should be opened against the `dev` branch.
+
+*Note that the `pre_build` bin in the dev branch is never up-to-date.*


### PR DESCRIPTION
Moves guidelines for contribution from issue #176 to a file in the repository. Github will show a message with this file to contributors, increasing its visibility.

Closes #176
